### PR TITLE
Update allowed versions of logstash-mixin-aws dependency to allow use in logstash 7.16.1 

### DIFF
--- a/logstash-input-s3-sns-sqs.gemspec
+++ b/logstash-input-s3-sns-sqs.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 2.1.12", "<= 2.99"
 
   s.add_runtime_dependency 'logstash-codec-json', '~> 3.0'
-  s.add_runtime_dependency 'logstash-mixin-aws', '~> 4.3'
+  s.add_runtime_dependency 'logstash-mixin-aws', '>= 4.3'
   s.add_development_dependency 'logstash-codec-json_stream', '~> 1.0'
   s.add_development_dependency 'logstash-devutils', '~> 1.3'
 end


### PR DESCRIPTION
Potentially addresses #67.

`logstash-mixin-aws` v5.0.0 [drops support for AWS SDK v1](https://github.com/logstash-plugins/logstash-mixin-aws/blob/main/CHANGELOG.md#500), but I do not see any references to the removed code in this plugin, which I think means it should be upgradeable without other changes.

If there is a specific testing process, I am happy to do that.

`logstash-mixin-aws` v5.0.0 is the default version in the newly released logstash (v7.16.1), which addresses a log4j vulnerability, meaning this could be a high priority change.

I'm not sure if [this dependency](https://github.com/cherweg/logstash-input-s3-sns-sqs/blob/480cf2f5a8fab0d8d217ed04f4647c867865095a/Gemfile.lock#L20) is impacted by this change.