### PR TITLE
Properly handle gzip files & update docs

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -205,7 +205,7 @@ Messages will be requeued after visibility timeout.
 ===== `sqs_delete_on_failure`
 
   * Value type is <<boolean,boolean>>
-  * The default value for this setting is FALSE.
+  * Default: true
 
 Skip delete of sqs messages causing a hard error or timeout inside the poller and try again.
 Maybe you are lucky...maybe you are not.
@@ -232,7 +232,7 @@ How many SQS reader should be started
 ===== `visibility_timeout` 
 
   * Value type is <<number,number>>
-  * Default: 5 Minutes.
+  * Default: 120 seconds
 
 The default visibility timeout for an SQS Message. If there is no
 "exit 0, successful" from the code block the SQS message will be

--- a/lib/logstash/inputs/s3snssqs/log_processor.rb
+++ b/lib/logstash/inputs/s3snssqs/log_processor.rb
@@ -77,8 +77,7 @@ module LogProcessor
   end
 
   def gzip?(filename)
-    return true if filename.end_with?('.gz','.gzip')
-    MagicGzipValidator.new(File.new(filename, 'rb')).valid?
+    filename.end_with?('.gz','.gzip') && MagicGzipValidator.new(File.new(filename, 'rb')).valid?
   rescue Exception => e
     @logger.warn("Problem while gzip detection", :error => e)
   end


### PR DESCRIPTION
Fix #71
MagicGzipValidator is never reached if file extension is .gz or .gzip.
Fix check to require both right extension presence and being a valid gzip file.
+ updates docs with default values according to sources - fix #48 