### PR TITLE
Deprecate 'from_sns' 

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -79,6 +79,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-delete_on_success>>|<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-include_object_properties>>|<<array,array>>|No
 | <<plugins-{type}s-{plugin}-from_sns>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-sns_raw_payload_delivery_disabled>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-sqs_skip_delete>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-sqs_delete_on_failure>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-temporary_directory>> |<<string,string>>|No
@@ -186,11 +187,20 @@ Example:
 
 [id="plugins-{type}s-{plugin}-from_sns"]
 ===== `from_sns` 
+WARNING: This setting is deprecated; replaced with `sns_raw_payload_delivery_disabled`.
 
   * Value type is <<boolean,boolean>>
-  * Default: true
+  * Default: false
 
-The message format is different, if the message comes from SNS.
+See <<plugins-{type}s-{plugin}-sns_raw_payload_delivery_disabled>>, this setting does the same task, it remains (for now) for backwards compatibility with previous versions of this plugin, it will soon be removed!
+
+[id="plugins-{type}s-{plugin}-sns_raw_payload_delivery_disabled"]
+===== `sns_raw_payload_delivery_disabled`
+
+  * Value type is <<boolean,boolean>>
+  * Default: false
+
+If you disable https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html[Amazon SNS raw message delivery] the format of messages will differ, this you need to enable this to ensure compatibility. If you're using a standard SNS setup, this will *not* be required.
 
 [id="plugins-{type}s-{plugin}-sqs_skip_delete"]
 ===== `sqs_skip_delete` 

--- a/lib/logstash/inputs/s3snssqs.rb
+++ b/lib/logstash/inputs/s3snssqs.rb
@@ -170,8 +170,12 @@ class LogStash::Inputs::S3SNSSQS < LogStash::Inputs::Threadable
   # Name of the SQS Queue to pull messages from. Note that this is just the name of the queue, not the URL or ARN.
   config :queue, :validate => :string, :required => true
   config :queue_owner_aws_account_id, :validate => :string, :required => false
-  # Whether the event is processed though an SNS to SQS. (S3>SNS>SQS = true |S3>SQS=false)
-  config :from_sns, :validate => :boolean, :default => true
+
+  # Should be enabled if 'SNS raw message delivery' is disabled
+  # 'from_sns' is soon to be deprecated, remains for compatibility
+  config :from_sns, :validate => :boolean, :default => false
+  config :sns_raw_payload_delivery_disabled, :validate => :boolean, :default => false
+
   config :sqs_skip_delete, :validate => :boolean, :default => false
   config :sqs_wait_time_seconds, :validate => :number, :required => false
   config :sqs_delete_on_failure, :validate => :boolean, :default => true
@@ -259,6 +263,7 @@ class LogStash::Inputs::S3SNSSQS < LogStash::Inputs::Threadable
         sqs_queue: @queue,
         queue_owner_aws_account_id: @queue_owner_aws_account_id,
         from_sns: @from_sns,
+        sns_raw_payload_delivery_disabled: @sns_raw_payload_delivery_disabled,
         max_processing_time: @max_processing_time,
         sqs_delete_on_failure: @sqs_delete_on_failure
       },

--- a/lib/logstash/inputs/sqs/poller.rb
+++ b/lib/logstash/inputs/sqs/poller.rb
@@ -40,6 +40,7 @@ class SqsPoller
     @stopped = stop_semaphore
     @queue = client_options[:sqs_queue]
     @from_sns = client_options[:from_sns]
+    @sns_raw_payload_delivery_disabled = client_options[:sns_raw_payload_delivery_disabled]
     @max_processing_time = client_options[:max_processing_time]
     @sqs_delete_on_failure = client_options[:sqs_delete_on_failure]
     @options = DEFAULT_OPTIONS.merge(poller_options)
@@ -148,7 +149,7 @@ class SqsPoller
   def preprocess(message)
     @logger.debug("Inside Preprocess: Start", :event => message)
     payload = JSON.parse(message.body)
-    payload = JSON.parse(payload['Message']) if @from_sns
+    payload = JSON.parse(payload['Message']) if @from_sns || @sns_raw_payload_delivery_disabled
     @logger.debug("Payload in Preprocess: ", :payload => payload)
     return nil unless payload['Records']
     payload['Records'].each do |record|


### PR DESCRIPTION
### Context 
**This PR is (at-least initially-_hence draft_) intended to be a discussion**, as I do not fully understand why `from_sns` is needed, as far as I can tell the payload format when `S3->SNS->SQS` architecture is deployed, the payload resembles the following:
```JSON
{
    "Records": [
      {
        "eventVersion": "2.1",
        "eventSource": "aws:s3",
        "awsRegion": "obfuscated",
        "eventTime": "2024-01-01T00:00:00.000Z",
        "eventName": "ObjectCreated:Put",
        "userIdentity": {
          "principalId": "AWS:obfuscated"
        },
        "requestParameters": {
          "sourceIPAddress": "obfuscated"
        },
        "responseElements": {
          "x-amz-request-id": "obfuscated",
          "x-amz-id-2": "obfuscated"
        },
        "s3": {
          "s3SchemaVersion": "1.0",
          "configurationId": "obfuscated",
          "bucket": {
            "name": "obfuscated",
            "ownerIdentity": {
              "principalId": "obfuscated"
            },
            "arn": "arn:aws:s3:obfuscated"
          },
          "object": {
            "key": "obfuscated",
            "size": 0,
            "eTag": "obfuscated",
            "versionId": "obfuscated",
            "sequencer": "obfuscated"
          }
        }
      }
    ]
  }
  ```
Which is inline with https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html

So, attempting to `payload = JSON.parse(payload['Message']) if @from_sns` will fail as of course, the JSON structure does not match that expectation. 

There are number of issues I have seen, related to this:
* https://github.com/cherweg/logstash-input-s3-sns-sqs/issues/54
* https://github.com/cherweg/logstash-input-s3-sns-sqs/issues/57
* https://github.com/cherweg/logstash-input-s3-sns-sqs/issues/80

### Why removal?
I do not currently understand how this payload would ever be nested within `payload['Message']`; though if there is a case where this would be the case - we should improve documentation to reflect this, and probably the naming of the variable. 

Currently, `from_sns` needs to equal `false` even when the data does originate from SNS - contrary to the comment in code `Whether the event is processed though an SNS to SQS. (S3>SNS>SQS = true |S3>SQS=false)` (and inference made in documentation) 

@cherweg maybe you will know if I am missing something here?